### PR TITLE
User Story 4: items_ready_to_ship

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -10,4 +10,10 @@ class Merchant < ApplicationRecord
             .group(:id)
             .limit(5)
   end
+
+  def items_ready_to_ship
+    InvoiceItem.joins(:invoice, { item: :merchant })
+               .where("invoice_items.status < 2 AND merchants.id = #{self.id}")
+               .order("invoice_items.created_at")
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,9 +3,15 @@
 <h3><%= link_to "View Items", "/merchants/#{@merchant.id}/items" %></h3>
 <h3><%= link_to "View Invoices", "/merchants/#{@merchant.id}/invoices" %></h3>
 
-<h2><%= "Best Customers:" %></h2>
+<h2><%= "Best Customers" %></h2>
 <ul>
     <% @merchant.top_five_customers.each do |customer| %>
         <h3><li><%= "#{customer.first_name} #{customer.last_name} (#{customer.number_of_transactions} Transactions)" %></li></h3>
+    <% end %>
+</ul>
+<h2><%= "Items Ready To Ship" %></h2>
+<ul>
+    <% @merchant.items_ready_to_ship.each do |invoice_item| %>
+        <h3><li><%= "#{invoice_item.item.name}" %>, <%= link_to "Invoice ##{invoice_item.invoice.id}", merchant_invoice_path(merchant_id: @merchant.id, id: invoice_item.invoice.id) %></li></h3>
     <% end %>
 </ul>

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "the merchant dashboard index page" do
     it "shows the merchant's name" do
       merchant = create(:merchant)
 
-      visit "/merchants/#{merchant.id}/dashboard"
+      visit merchant_dashboard_index_path(merchant_id: merchant.id)
 
       expect(page).to have_content(merchant.name)
     end
@@ -24,7 +24,7 @@ RSpec.describe "the merchant dashboard index page" do
     it "shows links to the merchant's item and invoice indices" do
       merchant = create(:merchant)
 
-      visit "/merchants/#{merchant.id}/dashboard"
+      visit merchant_dashboard_index_path(merchant_id: merchant.id)
 
       expect(page).to have_link 'View Items', href: "/merchants/#{merchant.id}/items"
       expect(page).to have_link 'View Invoices', href: "/merchants/#{merchant.id}/invoices"
@@ -41,7 +41,7 @@ RSpec.describe "the merchant dashboard index page" do
     it "shows the names of the top 5 customers (by number of successful transactions with merchant)" do
       load_test_data_us_3
 
-      visit "/merchants/#{@merchant.id}/dashboard"
+      visit merchant_dashboard_index_path(merchant_id: @merchant.id)
 
       expect(page).to have_content("#{@customer_1.first_name} #{@customer_1.last_name}")
       expect(page).to have_content("#{@customer_2.first_name} #{@customer_2.last_name}")
@@ -53,15 +53,60 @@ RSpec.describe "the merchant dashboard index page" do
     it "shows each customer's number of successful transactions with the merchant" do
       load_test_data_us_3
 
-      visit "/merchants/#{@merchant.id}/dashboard"
-
-      save_and_open_page
+      visit merchant_dashboard_index_path(merchant_id: @merchant.id)
 
       expect(page).to have_content("5 Transactions")
       expect(page).to have_content("4 Transactions")
       expect(page).to have_content("3 Transactions")
       expect(page).to have_content("2 Transactions")
       expect(page).to have_content("1 Transactions")
+    end
+  end
+
+  describe "User Story 4" do
+    # As a merchant
+    # When I visit my merchant dashboard (/merchants/:merchant_id/dashboard)
+    # Then I see a section for "Items Ready to Ship"
+    # In that section I see a list of the names of all of my items that have been ordered and have not yet been shipped,
+    # And next to each Item I see the id of the invoice that ordered my item
+    # And each invoice id is a link to my merchant's invoice show page
+
+    it "shows the names and invoice IDs of all items ready to ship (i.e. statuses of 'pending' or 'packaged')" do
+      load_test_data_us_4
+
+      visit merchant_dashboard_index_path(merchant_id: @merchant.id)
+
+      expect(page).to have_content("#{@invoice_item_1.item.name}, Invoice ##{@invoice_item_1.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_2.item.name}, Invoice ##{@invoice_item_2.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_3.item.name}, Invoice ##{@invoice_item_3.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_4.item.name}, Invoice ##{@invoice_item_4.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_5.item.name}, Invoice ##{@invoice_item_5.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_6.item.name}, Invoice ##{@invoice_item_6.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_7.item.name}, Invoice ##{@invoice_item_7.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_8.item.name}, Invoice ##{@invoice_item_8.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_9.item.name}, Invoice ##{@invoice_item_9.invoice.id}")
+      expect(page).to_not have_content("#{@invoice_item_10.item.name}, Invoice ##{@invoice_item_10.invoice.id}")
+      expect(page).to_not have_content("#{@invoice_item_11.item.name}, Invoice ##{@invoice_item_11.invoice.id}")
+    end
+
+    it "links to each item's invoice show page" do
+      load_test_data_us_4
+
+      visit merchant_dashboard_index_path(merchant_id: @merchant.id)
+
+      expect(page).to have_link "Invoice ##{@invoice_item_1.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_1.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_2.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_2.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_3.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_3.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_4.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_4.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_5.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_5.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_6.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_6.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_7.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_7.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_8.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_8.invoice.id)
+      expect(page).to have_link "Invoice ##{@invoice_item_9.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_9.invoice.id)
+      expect(page).to_not have_link "Invoice ##{@invoice_item_10.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_10.invoice.id)
+      expect(page).to_not have_link "Invoice ##{@invoice_item_11.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_11.invoice.id)
+
+      save_and_open_page
     end
   end
 end

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -105,8 +105,6 @@ RSpec.describe "the merchant dashboard index page" do
       expect(page).to have_link "Invoice ##{@invoice_item_9.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_9.invoice.id)
       expect(page).to_not have_link "Invoice ##{@invoice_item_10.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_10.invoice.id)
       expect(page).to_not have_link "Invoice ##{@invoice_item_11.invoice.id}", href: merchant_invoice_path(merchant_id: @merchant.id, id: @invoice_item_11.invoice.id)
-
-      save_and_open_page
     end
   end
 end

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -37,3 +37,32 @@ def load_test_data_us_3
         create(:transaction, invoice_id: invoice.id, result: 1)
     end
 end
+
+def load_test_data_us_4
+    @merchant = create(:merchant)
+    @merchant_2 = create(:merchant)
+
+    @item_1 = create(:item, merchant_id: @merchant.id)
+    @item_2 = create(:item, merchant_id: @merchant.id)
+    @item_3 = create(:item, merchant_id: @merchant.id)
+    @item_4 = create(:item, merchant_id: @merchant.id)
+    @item_5 = create(:item, merchant_id: @merchant.id)
+    @item_6 = create(:item, merchant_id: @merchant.id)
+    @item_7 = create(:item, merchant_id: @merchant.id)
+    @item_8 = create(:item, merchant_id: @merchant.id)
+    @item_9 = create(:item, merchant_id: @merchant.id)
+    @item_10 = create(:item, merchant_id: @merchant.id) # Sad path should exclude, invalid status from @invoice_item_10
+    @item_11 = create(:item, merchant_id: @merchant_2.id) # Belongs to @merchant_2 for sad path testing
+
+    @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, status: 0)
+    @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, status: 0)
+    @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, status: 0)
+    @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, status: 0)
+    @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, status: 0)
+    @invoice_item_6 = create(:invoice_item, item_id: @item_6.id, status: 1)
+    @invoice_item_7 = create(:invoice_item, item_id: @item_7.id, status: 1)
+    @invoice_item_8 = create(:invoice_item, item_id: @item_8.id, status: 1)
+    @invoice_item_9 = create(:invoice_item, item_id: @item_9.id, status: 1)
+    @invoice_item_10 = create(:invoice_item, item_id: @item_10.id, status: 2) # Sad path should exclude, due to status: 2 (shipped)
+    @invoice_item_11 = create(:invoice_item, item_id: @item_11.id) # Sad path should exclude, due to @item_11 belonging to @merchant_2 
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -33,6 +33,21 @@ RSpec.describe Merchant, type: :model do
         expect(@merchant.top_five_customers[3].number_of_transactions).to eq 2
         expect(@merchant.top_five_customers[4].number_of_transactions).to eq 1
       end
+    end
+
+    describe "#items_ready_to_ship (User Story 4)" do
+      # As a merchant
+      # When I visit my merchant dashboard (/merchants/:merchant_id/dashboard)
+      # Then I see a section for "Items Ready to Ship"
+      # In that section I see a list of the names of all of my items that have been ordered and have not yet been shipped,
+      # And next to each Item I see the id of the invoice that ordered my item
+      # And each invoice id is a link to my merchant's invoice show page
+  
+      it "returns all items that have been ordered but not yet shipped" do
+        load_test_data_us_4
+
+        expect(@merchant.items_ready_to_ship.sort).to eq([@invoice_item_1, @invoice_item_2, @invoice_item_3, @invoice_item_4, @invoice_item_5, @invoice_item_6, @invoice_item_7, @invoice_item_8, @invoice_item_9].sort)
+      end
     end 
   end
 end


### PR DESCRIPTION
This pull request adds the merchant model instance method `items_ready_to_ship`, which returns a sorted array of items with a shipping status of either "pending" or "packaged", along with that item's invoice number. 

The merchant dashboard displays each item's name, plus a link to its invoice show page.

I also reformatted the test links to utilize the link helpers, which I'll be doing with other user stories as well!