### PR TITLE
User Story 12: Merchant Items Index 5 Most Popular Items

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -28,4 +28,13 @@ class Merchant < ApplicationRecord
                .where("invoice_items.status < 2 AND merchants.id = #{self.id}")
                .order("invoice_items.created_at")
   end
+
+  def most_popular_items
+    Item.joins({invoices: :transactions}, :merchant)
+        .select("items.*, sum(invoice_items.quantity * invoice_items.unit_price) as total_item_revenue")
+        .where("transactions.result = 1 AND merchant_id = #{self.id}")
+        .order(total_item_revenue: :desc)
+        .group(:id)
+        .limit(5)
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,9 +9,12 @@
         <h3><li><%= "#{customer.first_name} #{customer.last_name} (#{customer.number_of_transactions} Transactions)" %></li></h3>
     <% end %>
 </ul>
+
 <h2><%= "Items Ready To Ship" %></h2>
 <ul>
     <% @merchant.items_ready_to_ship.each do |invoice_item| %>
-        <h3><li><%= "#{invoice_item.item.name}" %>, <%= link_to "Invoice ##{invoice_item.invoice.id}", merchant_invoice_path(merchant_id: @merchant.id, id: invoice_item.invoice.id) %>  (<%= "#{invoice_item.invoice.created_at.strftime("%A, %B #{invoice_item.invoice.created_at.day.ordinalize}, %Y")}" %>)</li></h3>
+        <li><h3><%= "#{invoice_item.item.name}" %></h3>
+        <h4><%= link_to "Invoice ##{invoice_item.invoice.id}", merchant_invoice_path(merchant_id: @merchant.id, id: invoice_item.invoice.id) %>
+         (<%= "#{invoice_item.invoice.created_at.strftime("%A, %B #{invoice_item.invoice.created_at.day.ordinalize}, %Y")}" %>)</h4></li>
     <% end %>
 </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,13 @@
 <h3 style="text-align: center;">My Items</h3>
 
+<h3><%= "Highest Revenue Items" %></h3>
+<ul>
+    <% @merchant.most_popular_items.each do |item| %>
+        <li><h4><%= link_to "#{item.name}", merchant_item_path(merchant_id: @merchant.id, item_id: item.id) %></h4>
+        <h4>(Total Item Revenue: <%= "#{item.total_item_revenue/100}" %>)</h4></li>
+    <% end %>
+</ul>
+
 <h3>Enabled Items</h3>
 <style>table, th, td </style>
 <table>

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -71,22 +71,40 @@ RSpec.describe "the merchant dashboard index page" do
     # And next to each Item I see the id of the invoice that ordered my item
     # And each invoice id is a link to my merchant's invoice show page
 
-    it "shows the names and invoice IDs of all items ready to ship (i.e. statuses of 'pending' or 'packaged')" do
+    it "shows the names of all items ready to ship (i.e. statuses of 'pending' or 'packaged')" do
       load_test_data_us_4
 
       visit merchant_dashboard_index_path(merchant_id: @merchant.id)
 
-      expect(page).to have_content("#{@invoice_item_1.item.name}, Invoice ##{@invoice_item_1.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_2.item.name}, Invoice ##{@invoice_item_2.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_3.item.name}, Invoice ##{@invoice_item_3.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_4.item.name}, Invoice ##{@invoice_item_4.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_5.item.name}, Invoice ##{@invoice_item_5.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_6.item.name}, Invoice ##{@invoice_item_6.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_7.item.name}, Invoice ##{@invoice_item_7.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_8.item.name}, Invoice ##{@invoice_item_8.invoice.id}")
-      expect(page).to have_content("#{@invoice_item_9.item.name}, Invoice ##{@invoice_item_9.invoice.id}")
-      expect(page).to_not have_content("#{@invoice_item_10.item.name}, Invoice ##{@invoice_item_10.invoice.id}")
-      expect(page).to_not have_content("#{@invoice_item_11.item.name}, Invoice ##{@invoice_item_11.invoice.id}")
+      expect(page).to have_content("#{@invoice_item_1.item.name}")
+      expect(page).to have_content("#{@invoice_item_2.item.name}")
+      expect(page).to have_content("#{@invoice_item_3.item.name}")
+      expect(page).to have_content("#{@invoice_item_4.item.name}")
+      expect(page).to have_content("#{@invoice_item_5.item.name}")
+      expect(page).to have_content("#{@invoice_item_6.item.name}")
+      expect(page).to have_content("#{@invoice_item_7.item.name}")
+      expect(page).to have_content("#{@invoice_item_8.item.name}")
+      expect(page).to have_content("#{@invoice_item_9.item.name}")
+      expect(page).to_not have_content("#{@invoice_item_10.item.name}")
+      expect(page).to_not have_content("#{@invoice_item_11.item.name}")
+    end
+
+    it "shows the invoice IDs of all items ready to ship (i.e. statuses of 'pending' or 'packaged')" do
+      load_test_data_us_4
+
+      visit merchant_dashboard_index_path(merchant_id: @merchant.id)
+
+      expect(page).to have_content("Invoice ##{@invoice_item_1.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_2.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_3.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_4.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_5.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_6.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_7.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_8.invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice_item_9.invoice.id}")
+      expect(page).to_not have_content("Invoice ##{@invoice_item_10.invoice.id}")
+      expect(page).to_not have_content("Invoice ##{@invoice_item_11.invoice.id}")
     end
 
     it "links to each item's invoice show page" do

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -59,4 +59,56 @@ RSpec.describe "the merchant items index page" do
       end
     end
   end
+
+  describe "User Story 12" do
+    # As a merchant
+    # When I visit my items index page
+    # Then I see the names of the top 5 most popular items ranked by total revenue generated
+    # And I see that each item name links to my merchant item show page for that item
+    # And I see the total revenue generated next to each item name
+    #
+    ### Notes on Revenue Calculation:
+    #
+    # - Only invoices with at least one successful transaction should count towards revenue
+    # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+    # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+
+    it "shows the names of the five best selling items (by total item revenue)" do
+      load_test_data_us_12
+
+      visit merchant_items_path(merchant_id: @merchant.id)
+
+      expect(page).to have_content("#{@item_6.name}")
+      expect(page).to have_content("#{@item_5.name}")
+      expect(page).to have_content("#{@item_4.name}")
+      expect(page).to have_content("#{@item_3.name}")
+      expect(page).to have_content("#{@item_2.name}")
+      expect(page).to_not have_content("#{@item_7.name}") # Item from other merchant/invoice
+    end
+
+    it "shows the total revenue of the five best selling items" do
+      load_test_data_us_12
+      
+      visit merchant_items_path(merchant_id: @merchant.id)
+
+      # Note: could we use money gem?
+      expect(page).to have_content("#{@merchant.most_popular_items[0].total_item_revenue/100}")
+      expect(page).to have_content("#{@merchant.most_popular_items[1].total_item_revenue/100}")
+      expect(page).to have_content("#{@merchant.most_popular_items[2].total_item_revenue/100}")
+      expect(page).to have_content("#{@merchant.most_popular_items[3].total_item_revenue/100}")
+      expect(page).to have_content("#{@merchant.most_popular_items[4].total_item_revenue/100}")
+    end
+
+    it "links to each item's invoice show page" do
+      load_test_data_us_12
+
+      visit merchant_items_path(merchant_id: @merchant.id)
+
+      expect(page).to have_link "#{@item_6.name}", href: merchant_item_path(merchant_id: @merchant.id, item_id: @item_6.id)
+      expect(page).to have_link "#{@item_5.name}", href: merchant_item_path(merchant_id: @merchant.id, item_id: @item_5.id)
+      expect(page).to have_link "#{@item_4.name}", href: merchant_item_path(merchant_id: @merchant.id, item_id: @item_4.id)
+      expect(page).to have_link "#{@item_3.name}", href: merchant_item_path(merchant_id: @merchant.id, item_id: @item_3.id)
+      expect(page).to have_link "#{@item_2.name}", href: merchant_item_path(merchant_id: @merchant.id, item_id: @item_2.id)
+    end
+  end
 end

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -66,3 +66,41 @@ def load_test_data_us_4
     @invoice_item_10 = create(:invoice_item, item_id: @item_10.id, status: 2) # Sad path should exclude, due to status: 2 (shipped)
     @invoice_item_11 = create(:invoice_item, item_id: @item_11.id) # Sad path should exclude, due to @item_11 belonging to @merchant_2 
 end
+
+def load_test_data_us_12
+    def format_unit_price
+        '$%.2f' % "#{total_item_revenue/100}"
+    end
+
+    @merchant = create(:merchant)
+    @merchant_2 = create(:merchant)
+
+    @item_1 = create(:item, merchant_id: @merchant.id)
+    @item_2 = create(:item, merchant_id: @merchant.id)
+    @item_3 = create(:item, merchant_id: @merchant.id)
+    @item_4 = create(:item, merchant_id: @merchant.id)
+    @item_5 = create(:item, merchant_id: @merchant.id)
+    @item_6 = create(:item, merchant_id: @merchant.id) # Sad path should exclude, sixth most popular item from @merchant_1
+    @item_7 = create(:item, merchant_id: @merchant_2.id) # Sad path should exclude, belongs to @merchant_2
+
+    @invoice_1 = create(:invoice)
+    @invoice_2 = create(:invoice)
+
+    @transaction = create(:transaction, invoice_id: @invoice_1.id, result: 1)
+    @transaction = create(:transaction, invoice_id: @invoice_2.id, result: 1)
+
+    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 10, unit_price: 5) # Sad path should exclude, sixth most popular item from @merchant_1
+    @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 10, unit_price: 10) # Sad path should exclude, sixth most popular item from @merchant_1
+    @invoice_item_3 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 10, unit_price: 10)
+    @invoice_item_4 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 10, unit_price: 15)
+    @invoice_item_5 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 10, unit_price: 15)
+    @invoice_item_6 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 10, unit_price: 20)
+    @invoice_item_7 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_4.id, quantity: 10, unit_price: 20)
+    @invoice_item_8 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_4.id, quantity: 10, unit_price: 25)
+    @invoice_item_9 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 10, unit_price: 25)
+    @invoice_item_10 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 10, unit_price: 30)
+    @invoice_item_11 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_6.id, quantity: 10, unit_price: 30)
+    @invoice_item_12 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_6.id, quantity: 10, unit_price: 35)
+    @invoice_item_13 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_7.id, quantity: 10, unit_price: 35) # Sad path should exclude, belongs to @merchant_2
+    @invoice_item_14 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_7.id, quantity: 10, unit_price: 40) # Sad path should exclude, belongs to @merchant_2
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -98,5 +98,25 @@ RSpec.describe Merchant, type: :model do
         expect(@merchant.items_ready_to_ship).to eq([@invoice_item_1, @invoice_item_2, @invoice_item_3, @invoice_item_4, @invoice_item_5, @invoice_item_6, @invoice_item_7, @invoice_item_8, @invoice_item_9])
       end
     end
+
+    describe "#most_popular_items (User Story 12: Merchant Items Index 5 most popular items)" do
+      # As a merchant
+      # When I visit my items index page
+      # Then I see the names of the top 5 most popular items ranked by total revenue generated
+      # And I see that each item name links to my merchant item show page for that item
+      # And I see the total revenue generated next to each item name
+      #
+      ### Notes on Revenue Calculation:
+      #
+      # - Only invoices with at least one successful transaction should count towards revenue
+      # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+      # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+
+      it "returns a list of the five most popular items, sorted DESC by total revenue generated" do
+        load_test_data_us_12
+
+        expect(@merchant.most_popular_items).to eq([@item_6, @item_5, @item_4, @item_3, @item_2])
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request adds the merchant model instance method `most_popular_items`, which returns an array of a merchant's five highest total items, sorted by highest revenue first.

This info has also been added to the merchant item index, along with links to each item's show page.